### PR TITLE
Fixed deprecation warning

### DIFF
--- a/lib/syoboi_calendar/client.rb
+++ b/lib/syoboi_calendar/client.rb
@@ -9,8 +9,8 @@ module SyoboiCalendar
     # @return [Faraday::Connection]
     def connection
       @connection ||= ::Faraday::Connection.new(url: ENDPOINT_BASE_URL) do |connection|
-        connection.adapter :net_http
         connection.response :xml
+        connection.adapter :net_http
       end
     end
 


### PR DESCRIPTION
# Before
```bash
$ be rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.
.WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.
.WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.
.WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.

(snip)

Finished in 0.2314 seconds
31 examples, 0 failures
```

# After
```bash
$ be rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
...............................

Finished in 0.18722 seconds
31 examples, 0 failures
```